### PR TITLE
Fix md4 deprecation issue in Node v17

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# Base project  https://github.com/gautamsi/node-ntlm-client (Nico Haller nico.haller@gmail.com)
+# Diff
+
+[ntlm2](https://github.com/v9u/node-ntlm-client) with Node v17 patch.
+
 # ntlm-client
 
 A node.js NTLM client with support for NTLM and NTLMv2 authentication

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const crypto = require('crypto');
+const md4 = require('js-md4');
 
 function createLMResponse(challenge, lmhash) {
 	let buf = new Buffer(24),
@@ -74,9 +75,9 @@ function createNTLMResponse(challenge, ntlmhash) {
 }
 
 function createNTLMHash(password) {
-	let md4sum = crypto.createHash('md4');
+	let md4sum = md4.create();
 	md4sum.update(new Buffer(password, 'ucs2'));
-	return md4sum.digest();
+	return Buffer.from(md4sum.digest());
 }
 
 function createNTLMv2Hash(ntlmhash, username, authTargetName) {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "extend": "^3.0.0"
+    "extend": "^3.0.0",
+    "js-md4": "^0.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ntlm2",
+  "name": "@tryjsky/ntlm2",
   "version": "0.3.1",
   "description": "ntlm2 with Node v17 patch.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ntlm2",
-  "version": "0.3.0",
-  "description": "A node.js NTLM client with support for NTLM and NTLMv2 authentication.Base project  https://github.com/gautamsi/node-ntlm-client",
+  "version": "0.3.1",
+  "description": "ntlm2 with Node v17 patch.",
   "keywords": [
     "ntlm",
     "ntlmv2",
@@ -10,15 +10,16 @@
   ],
   "main": "./lib/index.js",
   "author": {
-    "name": "v9u",
-    "email": "2808949242@qq.com"
+    "name": "Y., Ryota",
+    "email": "tryjsky@gmail.com",
+    "url": "https://github.com/tryjsky"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/v9u/node-ntlm-client.git"
+    "url": "https://github.com/tryjsky/node-ntlm-client.git"
   },
   "bugs": {
-    "url": "https://github.com/v9u/node-ntlm-client/issues"
+    "url": "https://github.com/tryjsky/node-ntlm-client/issues"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
This patch fixes the issue of md4 being deprecated in Node v17 crypto library. Using md4 will trigger a runtime error. This can cause problems for applications that rely on md4 for hashing or encryption.

One of such applications is SMB, which uses ntlm for authentication. ntlm uses md4 to generate a hash of the user's password and send it to the server. If md4 is deprecated, SMB authentication may fail.

The patch replaces hash function with js-md4.